### PR TITLE
Use heat and humidity to set weather.

### DIFF
--- a/weather/command.lua
+++ b/weather/command.lua
@@ -1,3 +1,9 @@
+function weather_mod.weather_cmd_set()
+	local weather_cmd = weather.cmd
+	weather.cmd = false
+	return weather_cmd or false
+end
+
 minetest.register_privilege("weather", {
 	description = "Change the weather",
 	give_to_singleplayer = false
@@ -10,20 +16,29 @@ minetest.register_chatcommand("setweather", {
 		show all types when no parameters are given", -- full description
 	privs = {weather = true},
 	func = function(name, param)
-		if param == nil or param == "" or param == "?" then
-			local types="none"
+		local types = "none"
+		local setparam = false
+		if param == "none" then
+			setparam = true
+		else
 			for i,_ in pairs(weather_mod.registered_downfalls) do
+				if i == param then
+					setparam = true
+					break
+				end
 				types=types..", "..i
 			end
-			minetest.chat_send_player(name, "avalible weather types: "..types)
+		end
+		if not setparam then
+			minetest.chat_send_player(name, "available weather types: "..types)
 		else
-			if weather_mod.registered_downfalls[param] == nil and not param == "none" then
-				minetest.chat_send_player(name, "This type of weather is not registered.\n"..
-					"To list all types of weather run the command without parameters.")
+			if param == "none" then
+				weather.cmd = false
 			else
-				weather.type = param
-				weather_mod.handle_lightning()
+				weather.cmd = true
 			end
+			weather.type = param
+			weather_mod.handle_lightning()
 		end
 	end
 })


### PR DESCRIPTION
Warning:

* This still lacks testing, especially on multiplayer servers. I am posting it early in hopes others might test it too.
* I am not confident on the precipitation chance values based on humidity, this may need fine tuning.
* I tested this on maggen v7 only.

Basically this uses the heat and humidity values from `minetest.get_biome_data(ppos)` at each individual player's location to set what kind of precipitation and how often.

Some things to note:

* Rain starts at `32` or more and it will snow at lower values. I'm not sure how well this matches up existing biome, but naturally snow starts at around 32 Fahrenheit.
* If it is raining or snowing and the player moves into a colder or hotter biome that weather type will change automatically.
* Using `/setweather <value>` will override this and it will not automatically change until the weather naturally stops or is disabled with `/setweather none`.
* The `/setweather` command now has more predictable usage and will only accept `none` and any defined weather types which currently include `weather:rain` and `weather:snow`. For any invalid input it will message the player with the available weather types.
* I added some log output for when the weather starts, changes or stops.
* Checking `biome.humidity`with any value greater than `85` does not work right, I'm not sure if this is problem with minetest, lua or my own error.